### PR TITLE
Update to also match JSX class strings

### DIFF
--- a/tailwind-order.py
+++ b/tailwind-order.py
@@ -17,7 +17,7 @@ class TailwindOrderCommand(sublime_plugin.TextCommand):
         file = sublime.load_resource(sublime.find_resources('data.json')[0])
         file = json.loads(file)
         dif = 0
-        classes = self.view.find_all('(?<=class=")(.*?)(?=")')
+        classes = self.view.find_all('(?<=class="|className=")(.*?)(?=")')
         for item in classes:
             filters = self.create_filters()
             item.a += dif


### PR DESCRIPTION
I updated the regex to also match `className="`, which is the syntax JSX uses to denote classes. This addition will make your library more inclusive, as many react-based projects use JSX over HTML.